### PR TITLE
Report HTTPS domain status when recording report

### DIFF
--- a/src/beacon.php
+++ b/src/beacon.php
@@ -228,6 +228,23 @@ class MCD_Beacon {
 			}
 		}
 
+		// Check if the domain supports HTTPS
+		if ( isset( $clean_data['blocked-uri'] ) ) {
+			$uri = $clean_data['blocked-uri'];
+
+			/**
+			 * When checking the blocked URI, we are only interested in full URI. Relative URIs will not be checked.
+			 * These are marked as -1 to represent an "unknown" status.
+			 */
+			if ( false !== strpos( $uri, 'http', 0 ) ) {
+				$result = ( true === mcd_uri_has_secure_version( $uri ) ) ? 1 : 0;
+			} else {
+				$result = -1;
+			}
+
+			update_post_meta( $post_id, 'valid-https-uri', $result );
+		}
+
 		exit();
 	}
 

--- a/src/wp-cli.php
+++ b/src/wp-cli.php
@@ -54,6 +54,7 @@ class MCD_Command extends WP_CLI_Command {
 				__( 'Violated Directive', 'zdt-mdc' ),
 				__( 'Original Policy', 'zdt-mdc' ),
 				__( 'Resolved', 'zdt-mdc' ),
+				__( 'Valid HTTPS URI', 'zdt-mdc' ),
 			) );
 
 			$table->setRows( $final_data );

--- a/src/wp-cli.php
+++ b/src/wp-cli.php
@@ -34,6 +34,14 @@ class MCD_Command extends WP_CLI_Command {
 			foreach ( $report as $subkey => $value ) {
 				if ( 'resolved' === $subkey ) {
 					$value = ( 1 === $value ) ? $resolved : $unresolved;
+				} else if ( 'valid-https-uri' === $subkey ) {
+					if ( 1 === $value ) {
+						$value = $resolved;
+					} elseif ( 0 === $value ) {
+						$value = $unresolved;
+					} else {
+						$value = __( 'N/A', 'zdt-mdc' );
+					}
 				}
 
 				$final_data[ $key ][] = $value;


### PR DESCRIPTION
When a report is recorded, it should report whether the domain that is blocked can be connected via HTTPS. This will help in the effort to diagnose why a report is generated.
