### PR TITLE
Policy improvements

### DIFF
--- a/src/beacon.php
+++ b/src/beacon.php
@@ -308,7 +308,7 @@ class MCD_Beacon {
 	 */
 	public function sanitize_violated_directive( $value ) {
 		// Grab the whitelisted policy values
-		$whitelisted_values = mcd_get_policy()->get_policies();
+		$whitelisted_values = mcd_get_policy()->build_policy();
 
 		if ( in_array( $value, $whitelisted_values ) ) {
 			return $value;

--- a/src/beacon.php
+++ b/src/beacon.php
@@ -308,7 +308,7 @@ class MCD_Beacon {
 	 */
 	public function sanitize_violated_directive( $value ) {
 		// Grab the whitelisted policy values
-		$whitelisted_values = mcd_get_policy()->build_policy();
+		$whitelisted_values = mcd_get_policy()->get_policies();
 
 		if ( in_array( $value, $whitelisted_values ) ) {
 			return $value;

--- a/src/beacon.php
+++ b/src/beacon.php
@@ -154,8 +154,8 @@ class MCD_Beacon {
 				break;
 
 			case 'original-policy' :
-				$v_directive = get_post_meta( $post_id , 'original-policy' , true );
-				echo ( ! empty( $v_directive ) ) ? esc_html( wp_strip_all_tags( $v_directive ) ) : __( 'N/A', 'zdt-mcd' );
+				$original_policy = get_post_meta( $post_id , 'original-policy' , true );
+				echo ( ! empty( $original_policy ) ) ? esc_html( wp_strip_all_tags( $original_policy ) ) : __( 'N/A', 'zdt-mcd' );
 				break;
 		}
 	}

--- a/src/config.php
+++ b/src/config.php
@@ -7,41 +7,6 @@
 define( 'MCD_REPORT_URI', site_url( '/?mcd=report&nonce=' . wp_create_nonce( 'mcd-report-uri' ) ) );
 
 /**
- * Define the Content Security Policy.
- *
- * This is set up as a global value to enable overriding in a config file. By setting up the `$mcd_policies` global
- * variable, a developer can override this value from wp-config.php.
- *
- * @since 1.1.0.
- */
-global $mcd_policies;
-
-// Only use the default if another policy is not set
-if ( ! isset( $mcd_policies ) ) {
-	$mcd_policies = array(
-		'default-src' => "https: data: 'unsafe-inline' 'unsafe-eval'",
-		'child-src'   => "https:",
-		'connect-src' => "https:",
-		'font-src'    => "https: data:",
-		'img-src'     => "https: data:",
-		'media-src'   => "https:",
-		'object-src'  => "https:",
-		'script-src'  => "https: 'unsafe-inline' 'unsafe-eval'",
-		'style-src'   => "https: 'unsafe-inline'",
-		'report-uri'  => MCD_REPORT_URI
-	);
-}
-
-/**
- * Define the policies to monitor for.
- *
- * @since 1.0.0.
- */
-if ( ! defined( 'MCD_POLICY' ) ) {
-	define( 'MCD_POLICY', "default-src 'unsafe-inline' 'unsafe-eval' data: https:; report-uri " . MCD_REPORT_URI );
-}
-
-/**
  * Determine whether or not to monitor admin mixed content warnings.
  *
  * @since 1.0.0.

--- a/src/config.php
+++ b/src/config.php
@@ -7,6 +7,32 @@
 define( 'MCD_REPORT_URI', site_url( '/?mcd=report&nonce=' . wp_create_nonce( 'mcd-report-uri' ) ) );
 
 /**
+ * Define the Content Security Policy.
+ *
+ * This is set up as a global value to enable overriding in a config file. By setting up the `$mcd_policies` global
+ * variable, a developer can override this value from wp-config.php.
+ *
+ * @since 1.1.0.
+ */
+global $mcd_policies;
+
+// Only use the default if another policy is not set
+if ( ! isset( $mcd_policies ) ) {
+	$mcd_policies = array(
+		'default-src' => "https: data: 'unsafe-inline' 'unsafe-eval'",
+		'child-src'   => "https:",
+		'connect-src' => "https:",
+		'font-src'    => "https: data:",
+		'img-src'     => "https: data:",
+		'media-src'   => "https:",
+		'object-src'  => "https:",
+		'script-src'  => "https: 'unsafe-inline' 'unsafe-eval'",
+		'style-src'   => "https: 'unsafe-inline'",
+		'report-uri'  => MCD_REPORT_URI
+	);
+}
+
+/**
  * Define the policies to monitor for.
  *
  * @since 1.0.0.

--- a/src/policy.php
+++ b/src/policy.php
@@ -129,7 +129,7 @@ class MCD_Policy {
 	 * @return array    Array of CSP policies.
 	 */
 	public function build_policy( $policies ) {
-		return implode( '; ', $this->build_full_individual_policies( $policies ) );
+		return implode( '; ', $this->build_full_individual_policies( $policies ) ) . '; report-uri ' . $this->get_report_url();
 	}
 
 	/**
@@ -193,7 +193,6 @@ class MCD_Policy {
 			'object-src'  => "https:",
 			'script-src'  => "https: 'unsafe-inline' 'unsafe-eval'",
 			'style-src'   => "https: 'unsafe-inline'",
-			'report-uri'  => MCD_REPORT_URI
 		);
 	}
 }

--- a/src/policy.php
+++ b/src/policy.php
@@ -104,6 +104,21 @@ class MCD_Policy {
 	}
 
 	/**
+	 * Get a list of policies set for the page load.
+	 *
+	 * Note that this function is intended to be used for breaking a CSP string into an array. It is primarily used for
+	 * whitelisting policies sent to the beacon.
+	 *
+	 * @since  1.0.0.
+	 * @since  1.1.0    Generate the list from the new default policies.
+	 *
+	 * @return array    A list of full policies.
+	 */
+	public function get_policies() {
+		return explode( '; ', $this->get_full_policy() );
+	}
+
+	/**
 	 * Return an array of policies for CSP.
 	 *
 	 * @since  1.0.0.

--- a/src/policy.php
+++ b/src/policy.php
@@ -87,6 +87,8 @@ class MCD_Policy {
 	 * @return string    The full policy
 	 */
 	public function get_full_policy() {
+		global $mcd_policies;
+
 		// Respect the global array of policies in version 1.1.x+
 		if ( isset( $mcd_policies ) ) {
 			$policy = $this->build_policy( $mcd_policies );


### PR DESCRIPTION
Version 1.0.0 of the plugin shipped with only the `default-src` policy being set. This works just fine; however, when a report is generated, there is no information about the specific type of violation. If we get more granular and set policy for individual categories of reports, we can category the reports as images, javascript, css, etc. This PR introduces more specific reporting. It also changes how the policy is defined to make it easier for others to define a different report if needed.
