### PR TITLE
Initial WP CLI commands

### DIFF
--- a/src/beacon.php
+++ b/src/beacon.php
@@ -228,6 +228,23 @@ class MCD_Beacon {
 			}
 		}
 
+		// Check if the domain supports HTTPS
+		if ( isset( $clean_data['blocked-uri'] ) ) {
+			$uri = $clean_data['blocked-uri'];
+
+			/**
+			 * When checking the blocked URI, we are only interested in full URI. Relative URIs will not be checked.
+			 * These are marked as -1 to represent an "unknown" status.
+			 */
+			if ( false !== strpos( $uri, 'http', 0 ) ) {
+				$result = ( true === mcd_uri_has_secure_version( $uri ) ) ? 1 : 0;
+			} else {
+				$result = -1;
+			}
+
+			update_post_meta( $post_id, 'valid-https-uri', $result );
+		}
+
 		exit();
 	}
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -92,19 +92,19 @@ if ( ! function_exists( 'mcd_mark_all_violations_resolved' ) ) :
  *
  * @since  1.1.0.
  *
- * @return void
+ * @return int    The number of posts resolved.
  */
 function mcd_mark_all_violations_resolved() {
-	$violation_data = mcd_get_violation_data();
+	$violation_data = mcd_get_violation_data( -1 );
+	$resolutions    = 0;
 
 	foreach ( $violation_data as $post_id => $data ) {
-		mcd_mark_violation_resolved( $post_id );
+		if ( false !== mcd_mark_violation_resolved( $post_id ) ) {
+			$resolutions++;
+		}
 	}
 
-	// If there appear to be additional violations, remove them
-	if ( 999 === count( $violation_data ) ) {
-		mcd_mark_all_violations_resolved();
-	}
+	return $resolutions;
 }
 endif;
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -68,6 +68,9 @@ function mcd_get_violation_data( $num = 999 ) {
 			$original_policy = get_post_meta( get_the_ID(), 'original-policy', true );
 			$original_policy = ( ! empty( $original_policy ) ) ? $original_policy : __( 'N/A', 'zdt-mcd' );
 
+			$valid_https_uri = get_post_meta( get_the_ID(), 'valid-https-uri', true );
+			$valid_https_uri = ( '0' === $valid_https_uri || '1' === $valid_https_uri ) ? intval( $valid_https_uri ) :  -1;
+
 			$data[ get_the_ID() ] = array(
 				'id'                 => get_the_ID(),
 				'blocked-uri'        => get_the_title(),
@@ -76,7 +79,7 @@ function mcd_get_violation_data( $num = 999 ) {
 				'violated-directive' => $v_directive,
 				'original-policy'    => $original_policy,
 				'resolved'           => absint( get_post_meta( get_the_ID(), 'resolved', true ) ),
-				'valid-https-uri'    => intval( get_post_meta( get_the_ID(), 'valid-https-uri', true ) ),
+				'valid-https-uri'    => $valid_https_uri,
 			);
 		}
 	}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -82,3 +82,41 @@ function mcd_get_violation_data( $num = 999 ) {
 	return $data;
 }
 endif;
+
+if ( ! function_exists( 'mcd_mark_all_violations_resolved' ) ) :
+/**
+ * Mark all CSP Reports as resolved.
+ *
+ * "Marking" a report resolved is equivalent to deleting the post from the table.
+ *
+ * @since  1.1.0.
+ *
+ * @return void
+ */
+function mcd_mark_all_violations_resolved() {
+	$violation_data = mcd_get_violation_data();
+
+	foreach ( $violation_data as $post_id => $data ) {
+		mcd_mark_all_violations_resolved( $post_id );
+	}
+
+	// If there appear to be additional violations, remove them
+	if ( 999 === count( $violation_data ) ) {
+		mcd_mark_all_violations_resolved();
+	}
+}
+endif;
+
+if ( ! function_exists( 'mcd_mark_violation_resolved' ) ) :
+/**
+ * Mark a single CSP Report as resolved.
+ *
+ * @since  1.1.0.
+ *
+ * @param  int                   $id    The ID of the report to resolve.
+ * @return array|bool|WP_Post           The result of the resolution.
+ */
+function mcd_mark_violation_resolved( $id ) {
+	return wp_delete_post( $id, true );
+}
+endif;

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -69,6 +69,7 @@ function mcd_get_violation_data( $num = 999 ) {
 			$original_policy = ( ! empty( $original_policy ) ) ? $original_policy : __( 'N/A', 'zdt-mcd' );
 
 			$data[ get_the_ID() ] = array(
+				'id'                 => get_the_ID(),
 				'blocked-uri'        => get_the_title(),
 				'document-uri'       => get_post_meta( get_the_ID(), 'document-uri', true ),
 				'referrer'           => $referrer,

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -117,6 +117,6 @@ if ( ! function_exists( 'mcd_mark_violation_resolved' ) ) :
  * @return array|bool|WP_Post           The result of the resolution.
  */
 function mcd_mark_violation_resolved( $id ) {
-	return wp_delete_post( $id, true );
+	return update_post_meta( $id, 'resolved', 1 );
 }
 endif;

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -122,6 +122,42 @@ function mcd_mark_violation_resolved( $id ) {
 }
 endif;
 
+if ( ! function_exists( 'mcd_mark_all_violations_unresolved' ) ) :
+/**
+ * Mark all CSP Reports as unresolved.
+ *
+ * @since  1.1.0.
+ *
+ * @return int    The number of posts unresolved.
+ */
+function mcd_mark_all_violations_unresolved() {
+	$violation_data        = mcd_get_violation_data( - 1 );
+	$violations_unresolved = 0;
+
+	foreach ( $violation_data as $post_id => $data ) {
+		if ( false !== mcd_mark_violation_unresolved( $post_id ) ) {
+			$violations_unresolved++;
+		}
+	}
+
+	return $violations_unresolved;
+}
+endif;
+
+if ( ! function_exists( 'mcd_mark_violation_unresolved' ) ) :
+/**
+ * Mark a single CSP Report as unresolved.
+ *
+ * @since  1.1.0.
+ *
+ * @param  int                   $id    The ID of the report to unresolve.
+ * @return array|bool|WP_Post           The result of the action.
+ */
+function mcd_mark_violation_unresolved( $id ) {
+	return delete_post_meta( $id, 'resolved' );
+}
+endif;
+
 if ( ! function_exists( 'mcd_remove_all_violations' ) ) :
 /**
  * Remove all CSP violation reports.

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -90,8 +90,6 @@ if ( ! function_exists( 'mcd_mark_all_violations_resolved' ) ) :
 /**
  * Mark all CSP Reports as resolved.
  *
- * "Marking" a report resolved is equivalent to deleting the post from the table.
- *
  * @since  1.1.0.
  *
  * @return void

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -97,7 +97,7 @@ function mcd_mark_all_violations_resolved() {
 	$violation_data = mcd_get_violation_data();
 
 	foreach ( $violation_data as $post_id => $data ) {
-		mcd_mark_all_violations_resolved( $post_id );
+		mcd_mark_violation_resolved( $post_id );
 	}
 
 	// If there appear to be additional violations, remove them

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,0 +1,84 @@
+<?php
+
+if ( ! function_exists( 'mcd_get_violation_wp_query' ) ) :
+/**
+ * Get the violations that are currently logged in the form of a WP_Query.
+ *
+ * @since  1.1.0.
+ *
+ * @param  int         $num    The number of violations to query.
+ * @return WP_Query            The WP_Query containing the violations
+ */
+function mcd_get_violation_wp_query( $num = 999 ) {
+	// Determine number of violations to display
+	$num = ( ! empty( $num ) ) ? intval( $num ) : 999; // Use intval to allow -1 if desired
+
+	// Query for all violations
+	$violations = new WP_Query( array(
+		'post_type' => 'csp-report',
+		'posts_per_page' => $num,
+		'no_found_rows' => true,
+	) );
+
+	return $violations;
+}
+endif;
+
+if ( ! function_exists( 'mcd_get_violation_data' ) ) :
+/**
+ * Return CSP Report data in an easy to use manner.
+ *
+ * Note that none of the returned data is escaped. Since the data will need to be escaped depending on the
+ * particular situation in which is it used, it is the responsibility of the caller to handle escaping.
+ *
+ * Returned data is in the form of:
+ *
+ *   array(
+ *     'blocked-uri'        => '',
+ *     'document-uri'       => '',
+ *     'referrer'           => '',
+ *     'violated-directive' => '',
+ *     'original-policy'    => '',
+ *   )
+ *
+ * @since  1.1.0.
+ *
+ * @param  int      $num    The number of violations to get.
+ * @return array            The data for the violations.
+ */
+function mcd_get_violation_data( $num = 999 ) {
+	// Set a data collector
+	$data = array();
+
+	// Query for the violations
+	$violation_wp_query = mcd_get_violation_wp_query( $num );
+
+	// Package up the important data
+	if ( $violation_wp_query->have_posts() ) {
+		while ( $violation_wp_query->have_posts() ) {
+			$violation_wp_query->the_post();
+
+			$referrer = get_post_meta( get_the_ID(), 'document-uri', true );
+			$referrer = ( ! empty( $referrer ) ) ? $referrer : __( 'N/A', 'zdt-mcd' );
+
+			$v_directive = get_post_meta( get_the_ID(), 'violated-directive', true );
+			$v_directive = ( ! empty( $v_directive ) ) ? $v_directive : __( 'N/A', 'zdt-mcd' );
+
+			$original_policy = get_post_meta( get_the_ID(), 'original-policy', true );
+			$original_policy = ( ! empty( $original_policy ) ) ? $original_policy : __( 'N/A', 'zdt-mcd' );
+
+			$data[ get_the_ID() ] = array(
+				'blocked-uri'        => get_the_title(),
+				'document-uri'       => get_post_meta( get_the_ID(), 'document-uri', true ),
+				'referrer'           => $referrer,
+				'violated-directive' => $v_directive,
+				'original-policy'    => $original_policy,
+			);
+		}
+	}
+
+	wp_reset_postdata();
+
+	return $data;
+}
+endif;

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -121,3 +121,39 @@ function mcd_mark_violation_resolved( $id ) {
 	return update_post_meta( $id, 'resolved', 1 );
 }
 endif;
+
+if ( ! function_exists( 'mcd_remove_all_violations' ) ) :
+/**
+ * Remove all CSP violation reports.
+ *
+ * @since  1.1.0.
+ *
+ * @return int    The number of reports removed.
+ */
+function mcd_remove_all_violations() {
+	$violation_data = mcd_get_violation_data( -1 );
+	$removals       = 0;
+
+	foreach ( $violation_data as $post_id => $data ) {
+		if ( false !== mcd_remove_violation( $post_id ) ) {
+			$removals++;
+		}
+	}
+
+	return $removals;
+}
+endif;
+
+if ( ! function_exists( 'mcd_remove_violation' ) ) :
+/**
+ * Remove a single CSP report.
+ *
+ * @since  1.1.0.
+ *
+ * @param  int                   $id    The ID of the report to remove.
+ * @return array|bool|WP_Post           The result of the removal.
+ */
+function mcd_remove_violation( $id ) {
+	return wp_delete_post( $id, true );
+}
+endif;

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -39,6 +39,7 @@ if ( ! function_exists( 'mcd_get_violation_data' ) ) :
  *     'referrer'           => '',
  *     'violated-directive' => '',
  *     'original-policy'    => '',
+ *     'resolved'           => '',
  *   )
  *
  * @since  1.1.0.
@@ -73,6 +74,7 @@ function mcd_get_violation_data( $num = 999 ) {
 				'referrer'           => $referrer,
 				'violated-directive' => $v_directive,
 				'original-policy'    => $original_policy,
+				'resolved'           => absint( get_post_meta( get_the_ID(), 'resolved', true ) ),
 			);
 		}
 	}

--- a/src/https-mixed-content-detector.php
+++ b/src/https-mixed-content-detector.php
@@ -92,8 +92,13 @@ class MCD_Mixed_Content_Detector {
 
 		// Include dependent files
 		include $this->root_dir . '/config.php';
+		include $this->root_dir . '/helpers.php';
 		include $this->root_dir . '/beacon.php';
 		include $this->root_dir . '/policy.php';
+
+		if ( defined('WP_CLI') && WP_CLI ) {
+			include $this->root_dir . '/wp-cli.php';
+		}
 	}
 }
 endif;

--- a/src/wp-cli.php
+++ b/src/wp-cli.php
@@ -16,6 +16,10 @@ class MCD_Command extends WP_CLI_Command {
 	 * @return void
 	 */
 	public function _list() {
+		// Set up check and x marks
+		$resolved   = \cli\Colors::colorize( "%G✓%n", true );
+		$unresolved = \cli\Colors::colorize( "%R✖%n", true );
+
 		$data = mcd_get_violation_data();
 
 		// Reformat data for table display
@@ -23,6 +27,10 @@ class MCD_Command extends WP_CLI_Command {
 
 		foreach ( $data as $key => $report ) {
 			foreach ( $report as $subkey => $value ) {
+				if ( 'resolved' === $subkey ) {
+					$value = ( 1 === $value ) ? $resolved : $unresolved;
+				}
+
 				$final_data[ $key ][] = $value;
 			}
 		}
@@ -38,6 +46,7 @@ class MCD_Command extends WP_CLI_Command {
 			__( 'Referrer', 'zdt-mdc' ),
 			__( 'Violated Directive', 'zdt-mdc' ),
 			__( 'Original Policy', 'zdt-mdc' ),
+			__( 'Resolved', 'zdt-mdc' ),
 		) );
 
 		$table->setRows( $final_data );

--- a/src/wp-cli.php
+++ b/src/wp-cli.php
@@ -41,6 +41,7 @@ class MCD_Command extends WP_CLI_Command {
 		$table = new \cli\Table();
 
 		$table->setHeaders( array(
+			__( 'Report ID', 'zdt-mdc' ),
 			__( 'Blocked URI', 'zdt-mdc' ),
 			__( 'Document URI', 'zdt-mdc' ),
 			__( 'Referrer', 'zdt-mdc' ),

--- a/src/wp-cli.php
+++ b/src/wp-cli.php
@@ -74,7 +74,7 @@ class MCD_Command extends WP_CLI_Command {
 			$table->display();
 
 			// Print the key
-			WP_CLI::line( 'R = Resolved, S = Secure URI Available' );
+			WP_CLI::line( "\n  R = Resolved, S = Secure URI Available\n" );
 		} else {
 			WP_CLI::warning( __( 'There are no CSP violations logged.', 'zdt-mdc' ) );
 		}

--- a/src/wp-cli.php
+++ b/src/wp-cli.php
@@ -41,7 +41,7 @@ class MCD_Command extends WP_CLI_Command {
 						} elseif ( 0 === $value ) {
 							$value = $unresolved;
 						} else {
-							$value = __( 'N/A', 'zdt-mdc' );
+							$value = __( '-', 'zdt-mdc' );
 						}
 					}
 
@@ -68,6 +68,9 @@ class MCD_Command extends WP_CLI_Command {
 
 			$table->setRows( $final_data );
 			$table->display();
+
+			// Print the key
+			WP_CLI::line( 'R = Resolved, S = Secure URI Available' );
 		} else {
 			WP_CLI::warning( __( 'There are no CSP violations logged.', 'zdt-mdc' ) );
 		}

--- a/src/wp-cli.php
+++ b/src/wp-cli.php
@@ -85,11 +85,25 @@ class MCD_Command extends WP_CLI_Command {
 		$id  = ( ! empty( $args[0] ) ) ? absint( $args[0] ) : 0;
 		$all = ( isset( $assoc_args['all'] ) );
 
+		$resolutions = 0;
+
 		if ( 0 !== $id ) {
-			mcd_mark_violation_resolved( $id );
+			if ( false !== mcd_mark_violation_resolved( $id ) ) {
+				$resolutions++;
+			}
 		} elseif ( true === $all ) {
-			mcd_mark_all_violations_resolved();
+			$resolutions = mcd_mark_all_violations_resolved();
 		}
+
+		if ( $resolutions === 1 ) {
+			$message = '1 report marked as resolved';
+		} else if ( $resolutions > 1 ) {
+			$message = absint( $resolutions ) . ' reports marked as resolved';
+		} else {
+			$message = 'No reports marked as resolved';
+		}
+
+		WP_CLI::success( $message );
 	}
 }
 endif;

--- a/src/wp-cli.php
+++ b/src/wp-cli.php
@@ -56,15 +56,19 @@ class MCD_Command extends WP_CLI_Command {
 			// Display results
 			$table = new \cli\Table();
 
-			$table->setHeaders( array(
+			// Set up the Headers and Footers
+			$header_footers = array(
 				__( 'ID', 'zdt-mdc' ),
 				__( 'Blocked URI', 'zdt-mdc' ),
 				__( 'Document URI', 'zdt-mdc' ),
 				__( 'Referrer', 'zdt-mdc' ),
 				__( 'Violated Directive', 'zdt-mdc' ),
-				__( 'Status', 'zdt-mdc' ),
-				__( 'HTTPS', 'zdt-mdc' ),
-			) );
+				__( 'R', 'zdt-mdc' ),
+				__( 'S', 'zdt-mdc' ),
+			);
+
+			$table->setHeaders( $header_footers );
+			$table->setFooters( $header_footers );
 
 			$table->setRows( $final_data );
 			$table->display();

--- a/src/wp-cli.php
+++ b/src/wp-cli.php
@@ -54,6 +54,7 @@ class MCD_Command extends WP_CLI_Command {
 				__( 'Violated Directive', 'zdt-mdc' ),
 				__( 'Original Policy', 'zdt-mdc' ),
 				__( 'Resolved', 'zdt-mdc' ),
+				__( 'Valid HTTPS URI', 'zdt-mdc' ),
 			) );
 
 			$table->setRows( $final_data );

--- a/src/wp-cli.php
+++ b/src/wp-cli.php
@@ -54,7 +54,7 @@ class MCD_Command extends WP_CLI_Command {
 			$table->setRows( $final_data );
 			$table->display();
 		} else {
-			WP_CLI::warning( 'There are no CSP violations logged.' );
+			WP_CLI::warning( __( 'There are no CSP violations logged.', 'zdt-mdc' ) );
 		}
 	}
 
@@ -99,12 +99,18 @@ class MCD_Command extends WP_CLI_Command {
 			$resolutions = mcd_mark_all_violations_resolved();
 		}
 
-		if ( $resolutions === 1 ) {
-			$message = '1 report marked as resolved';
-		} else if ( $resolutions > 1 ) {
-			$message = absint( $resolutions ) . ' reports marked as resolved';
+		if ( 0 === $resolutions ) {
+			$message = __( 'No reports marked as resolved', 'zdt-mcd' );
 		} else {
-			$message = 'No reports marked as resolved';
+			$message = sprintf(
+				_n(
+					'1 report marked as resolved',
+					'%s reports marked as resolved',
+					absint( $resolutions ),
+					'zdt-mcd'
+				),
+				absint( $resolutions )
+			);
 		}
 
 		WP_CLI::success( $message );
@@ -151,12 +157,18 @@ class MCD_Command extends WP_CLI_Command {
 			$removals = mcd_remove_all_violations();
 		}
 
-		if ( $removals === 1 ) {
-			$message = '1 report removed';
-		} else if ( $removals > 1 ) {
-			$message = absint( $removals ) . ' reports removed';
+		if ( 0 === $removals ) {
+			$message = __( 'No reports removed', 'zdt-mcd' );
 		} else {
-			$message = 'No reports removed';
+			$message = sprintf(
+				_n(
+					'1 report removed',
+					'%s reports removed',
+					absint( $removals ),
+					'zdt-mcd'
+				),
+				absint( $removals )
+			);
 		}
 
 		WP_CLI::success( $message );

--- a/src/wp-cli.php
+++ b/src/wp-cli.php
@@ -15,14 +15,6 @@ class MCD_Command extends WP_CLI_Command {
 	 * @return void
 	 */
 	public function _list() {
-		/**
-		 * Colorizing the results leads to the table display incorrectly rendering the right hand border. This is due to
-		 * a bug in WP CLI (https://github.com/wp-cli/php-cli-tools/issues/59). Colors are pretty important to communicate
-		 * a failed checked, so this is implemented with a broken table display.
-		 */
-		$success = \cli\Colors::colorize( "%G✓%n", true );
-		$failure = \cli\Colors::colorize( "%R✖%n", true );
-
 		$data = mcd_get_violation_data();
 
 		// Reformat data for table display

--- a/src/wp-cli.php
+++ b/src/wp-cli.php
@@ -37,21 +37,25 @@ class MCD_Command extends WP_CLI_Command {
 
 		wp_reset_postdata();
 
-		// Display results
-		$table = new \cli\Table();
+		if ( count( $data ) > 0 ) {
+			// Display results
+			$table = new \cli\Table();
 
-		$table->setHeaders( array(
-			__( 'Report ID', 'zdt-mdc' ),
-			__( 'Blocked URI', 'zdt-mdc' ),
-			__( 'Document URI', 'zdt-mdc' ),
-			__( 'Referrer', 'zdt-mdc' ),
-			__( 'Violated Directive', 'zdt-mdc' ),
-			__( 'Original Policy', 'zdt-mdc' ),
-			__( 'Resolved', 'zdt-mdc' ),
-		) );
+			$table->setHeaders( array(
+				__( 'Report ID', 'zdt-mdc' ),
+				__( 'Blocked URI', 'zdt-mdc' ),
+				__( 'Document URI', 'zdt-mdc' ),
+				__( 'Referrer', 'zdt-mdc' ),
+				__( 'Violated Directive', 'zdt-mdc' ),
+				__( 'Original Policy', 'zdt-mdc' ),
+				__( 'Resolved', 'zdt-mdc' ),
+			) );
 
-		$table->setRows( $final_data );
-		$table->display();
+			$table->setRows( $final_data );
+			$table->display();
+		} else {
+			WP_CLI::warning( 'There are no CSP violations logged.' );
+		}
 	}
 
 	/**

--- a/src/wp-cli.php
+++ b/src/wp-cli.php
@@ -32,19 +32,21 @@ class MCD_Command extends WP_CLI_Command {
 
 		foreach ( $data as $key => $report ) {
 			foreach ( $report as $subkey => $value ) {
-				if ( 'resolved' === $subkey ) {
-					$value = ( 1 === $value ) ? $resolved : $unresolved;
-				} else if ( 'valid-https-uri' === $subkey ) {
-					if ( 1 === $value ) {
-						$value = $resolved;
-					} elseif ( 0 === $value ) {
-						$value = $unresolved;
-					} else {
-						$value = __( 'N/A', 'zdt-mdc' );
+				if ( 'original-policy' !== $subkey ) {
+					if ( 'resolved' === $subkey ) {
+						$value = ( 1 === $value ) ? $resolved : $unresolved;
+					} else if ( 'valid-https-uri' === $subkey ) {
+						if ( 1 === $value ) {
+							$value = $resolved;
+						} elseif ( 0 === $value ) {
+							$value = $unresolved;
+						} else {
+							$value = __( 'N/A', 'zdt-mdc' );
+						}
 					}
-				}
 
-				$final_data[ $key ][] = $value;
+					$final_data[ $key ][] = $value;
+				}
 			}
 		}
 
@@ -55,14 +57,13 @@ class MCD_Command extends WP_CLI_Command {
 			$table = new \cli\Table();
 
 			$table->setHeaders( array(
-				__( 'Report ID', 'zdt-mdc' ),
+				__( 'ID', 'zdt-mdc' ),
 				__( 'Blocked URI', 'zdt-mdc' ),
 				__( 'Document URI', 'zdt-mdc' ),
 				__( 'Referrer', 'zdt-mdc' ),
 				__( 'Violated Directive', 'zdt-mdc' ),
-				__( 'Original Policy', 'zdt-mdc' ),
-				__( 'Resolved', 'zdt-mdc' ),
-				__( 'Valid HTTPS URI', 'zdt-mdc' ),
+				__( 'Status', 'zdt-mdc' ),
+				__( 'HTTPS', 'zdt-mdc' ),
 			) );
 
 			$table->setRows( $final_data );

--- a/src/wp-cli.php
+++ b/src/wp-cli.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Define the "mcd" WP CLI command.
+ *
+ * @since 1.1.0.
+ */
+class MCD_Command extends WP_CLI_Command {
+	/**
+	 * List the violations.
+	 *
+	 * @since  1.1.0.
+	 *
+	 * @subcommand list
+	 *
+	 * @return void
+	 */
+	public function _list() {
+		/**
+		 * Colorizing the results leads to the table display incorrectly rendering the right hand border. This is due to
+		 * a bug in WP CLI (https://github.com/wp-cli/php-cli-tools/issues/59). Colors are pretty important to communicate
+		 * a failed checked, so this is implemented with a broken table display.
+		 */
+		$success = \cli\Colors::colorize( "%G✓%n", true );
+		$failure = \cli\Colors::colorize( "%R✖%n", true );
+
+		$data = mcd_get_violation_data();
+
+		// Reformat data for table display
+		$final_data = array();
+
+		foreach ( $data as $key => $report ) {
+			foreach ( $report as $subkey => $value ) {
+				$final_data[ $key ][] = $value;
+			}
+		}
+
+		wp_reset_postdata();
+
+		// Display results
+		$table = new \cli\Table();
+
+		$table->setHeaders( array(
+			__( 'Blocked URI', 'zdt-mdc' ),
+			__( 'Document URI', 'zdt-mdc' ),
+			__( 'Referrer', 'zdt-mdc' ),
+			__( 'Violated Directive', 'zdt-mdc' ),
+			__( 'Original Policy', 'zdt-mdc' ),
+		) );
+
+		$table->setRows( $final_data );
+		$table->display();
+	}
+}
+
+WP_CLI::add_command( 'mcd', 'MCD_Command' );

--- a/src/wp-cli.php
+++ b/src/wp-cli.php
@@ -1,4 +1,5 @@
 <?php
+if ( ! class_exists( 'MCD_Command' ) ) :
 /**
  * Define the "mcd" WP CLI command.
  *
@@ -43,5 +44,6 @@ class MCD_Command extends WP_CLI_Command {
 		$table->display();
 	}
 }
+endif;
 
 WP_CLI::add_command( 'mcd', 'MCD_Command' );

--- a/src/wp-cli.php
+++ b/src/wp-cli.php
@@ -122,6 +122,64 @@ class MCD_Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Unresolve a single or multiple CSP Reports.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [<id>]
+	 * : The ID of the CSP Report to unresolve.
+	 *
+	 * [--all]
+	 * : Unresolve all CSP Reports.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Unresolve CSP Report with post ID of 35
+	 *     wp mcd unresolve 35
+	 *
+	 *     # Unresolve all CSP Reports
+	 *     wp mcd unresolve --all
+	 *
+	 * @since 1.1.0.
+	 *
+	 * @subcommand unresolve
+	 *
+	 * @param  array    $args          List of arguments passed to command.
+	 * @param  array    $assoc_args    List of flags passed to command
+	 * @return void
+	 */
+	public function _unresolve( $args, $assoc_args ) {
+		$id  = ( ! empty( $args[0] ) ) ? absint( $args[0] ) : 0;
+		$all = ( isset( $assoc_args['all'] ) );
+
+		$violations_unresolved = 0;
+
+		if ( 0 !== $id ) {
+			if ( false !== mcd_mark_violation_unresolved( $id ) ) {
+				$violations_unresolved++;
+			}
+		} elseif ( true === $all ) {
+			$violations_unresolved = mcd_mark_all_violations_unresolved();
+		}
+
+		if ( 0 === $violations_unresolved ) {
+			$message = __( 'No reports marked as unresolved', 'zdt-mcd' );
+		} else {
+			$message = sprintf(
+				_n(
+					'1 report marked as unresolved',
+					'%s reports marked as unresolved',
+					absint( $violations_unresolved ),
+					'zdt-mcd'
+				),
+				absint( $violations_unresolved )
+			);
+		}
+
+		WP_CLI::success( $message );
+	}
+
+	/**
 	 * Remove a single or multiple CSP Reports.
 	 *
 	 * ## OPTIONS

--- a/src/wp-cli.php
+++ b/src/wp-cli.php
@@ -43,6 +43,44 @@ class MCD_Command extends WP_CLI_Command {
 		$table->setRows( $final_data );
 		$table->display();
 	}
+
+	/**
+	 * Remove a single or multiple CSP Reports.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [<id>]
+	 * : The ID of the CSP Report to resolve.
+	 *
+	 * [--all]
+	 * : Remove all CSP Reports.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Resolve CSP Report with post ID of 35
+	 *     wp mcd resolve 35
+	 *
+	 *     # Remove all CSP Reports
+	 *     wp mcd resolve --all
+	 *
+	 * @since 1.1.0.
+	 *
+	 * @subcommand resolve
+	 *
+	 * @param  array    $args          List of arguments passed to command.
+	 * @param  array    $assoc_args    List of flags passed to command
+	 * @return void
+	 */
+	public function _resolve( $args, $assoc_args ) {
+		$id  = ( ! empty( $args[0] ) ) ? absint( $args[0] ) : 0;
+		$all = ( isset( $assoc_args['all'] ) );
+
+		if ( 0 !== $id ) {
+			mcd_mark_violation_resolved( $id );
+		} elseif ( true === $all ) {
+			mcd_mark_all_violations_resolved();
+		}
+	}
 }
 endif;
 

--- a/src/wp-cli.php
+++ b/src/wp-cli.php
@@ -34,6 +34,14 @@ class MCD_Command extends WP_CLI_Command {
 			foreach ( $report as $subkey => $value ) {
 				if ( 'resolved' === $subkey ) {
 					$value = ( 1 === $value ) ? $resolved : $unresolved;
+				} else if ( 'valid-https-uri' === $subkey ) {
+					if ( 1 === $value ) {
+						$value = $resolved;
+					} elseif ( 0 === $value ) {
+						$value = $unresolved;
+					} else {
+						$value = __( 'N/A', 'zdt-mdc' );
+					}
 				}
 
 				$final_data[ $key ][] = $value;

--- a/src/wp-cli.php
+++ b/src/wp-cli.php
@@ -55,7 +55,7 @@ class MCD_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Remove a single or multiple CSP Reports.
+	 * Resolve a single or multiple CSP Reports.
 	 *
 	 * ## OPTIONS
 	 *
@@ -63,7 +63,7 @@ class MCD_Command extends WP_CLI_Command {
 	 * : The ID of the CSP Report to resolve.
 	 *
 	 * [--all]
-	 * : Remove all CSP Reports.
+	 * : Resolve all CSP Reports.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -101,6 +101,58 @@ class MCD_Command extends WP_CLI_Command {
 			$message = absint( $resolutions ) . ' reports marked as resolved';
 		} else {
 			$message = 'No reports marked as resolved';
+		}
+
+		WP_CLI::success( $message );
+	}
+
+	/**
+	 * Remove a single or multiple CSP Reports.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [<id>]
+	 * : The ID of the CSP Report to remove.
+	 *
+	 * [--all]
+	 * : Remove all CSP Reports.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Resolve CSP Report with post ID of 35
+	 *     wp mcd remove 35
+	 *
+	 *     # Remove all CSP Reports
+	 *     wp mcd remove --all
+	 *
+	 * @since 1.1.0.
+	 *
+	 * @subcommand remove
+	 *
+	 * @param  array    $args          List of arguments passed to command.
+	 * @param  array    $assoc_args    List of flags passed to command
+	 * @return void
+	 */
+	public function _remove( $args, $assoc_args ) {
+		$id  = ( ! empty( $args[0] ) ) ? absint( $args[0] ) : 0;
+		$all = ( isset( $assoc_args['all'] ) );
+
+		$removals = 0;
+
+		if ( 0 !== $id ) {
+			if ( false !== mcd_remove_violation( $id ) ) {
+				$removals++;
+			}
+		} elseif ( true === $all ) {
+			$removals = mcd_remove_all_violations();
+		}
+
+		if ( $removals === 1 ) {
+			$message = '1 report removed';
+		} else if ( $removals > 1 ) {
+			$message = absint( $removals ) . ' reports removed';
+		} else {
+			$message = 'No reports removed';
 		}
 
 		WP_CLI::success( $message );

--- a/src/wp-cli.php
+++ b/src/wp-cli.php
@@ -7,7 +7,12 @@ if ( ! class_exists( 'MCD_Command' ) ) :
  */
 class MCD_Command extends WP_CLI_Command {
 	/**
-	 * List the violations.
+	 * List the all of the violations logged.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Show all violations
+	 *     wp mcd list
 	 *
 	 * @since  1.1.0.
 	 *


### PR DESCRIPTION
This PR introduces 4 WP CLI for viewing and managing CSP reports for this plugin:
1. `wp mcd list`: Lists all of the reports and prints out the following:
   - report ID 
   - blocked URI
   - document URI
   - referrer
   - violated directive
   - resolved status
   - secure URI status
2. `wp mcd resolve`: Allows you to mark an individual or all reports as resolved
3. `wp mcd unresolve`: Allows you to mark an individual or all reports as unresolved
4. `wp mcd remove`: Allows you to remov an individual or all reports

Styling of the table still leaves much to be desired, but that will improve over time.
