### PR TITLE
Only output the CSP header on https pages

### DIFF
--- a/src/policy.php
+++ b/src/policy.php
@@ -67,7 +67,7 @@ class MCD_Policy {
 		$monitor_admin     = defined( 'MCD_MONITOR_ADMIN' ) && true === MCD_MONITOR_ADMIN && is_admin();
 		$monitor_front_end = defined( 'MCD_MONITOR_FRONT_END' ) && true === MCD_MONITOR_FRONT_END && ! is_admin();
 
-		if ( $monitor_admin || $monitor_front_end ) {
+		if ( is_ssl() && ( $monitor_admin || $monitor_front_end ) ) {
 			header( $this->get_cps_header() );
 		}
 	}


### PR DESCRIPTION
A multisite setup of mine has some sites which are served over `https` on the front end and some which aren't. (I'm tracking CSP errors in the admin areas, which are served over `https`.)

HTTPS Mixed Content Detector outputs its CSP header on the front end regardless of whether or not the page is served over `https`. This means the CSP log for the sites served over `http` gets needlessly filled up with reports which trigger for almost every asset on the page.

This fixes that.
