### PR TITLE
Consider whether re-requesting all URLs over HTTPS is safe

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -219,11 +219,24 @@ if ( ! function_exists( 'mcd_is_valid_uri') ) :
  * @return bool              True if URI is connectable; false if it is not.
  */
 function mcd_is_valid_uri( $uri ) {
+	$pieces = parse_url( $uri );
+
+	if ( ! isset( $pieces['host'] ) ) {
+		return false;
+	}
+
+	// Piece the domain back together
+	$uri  = $pieces['host'];
+	$uri .= ( isset( $pieces['port'] ) ) ? ':' . absint( $pieces['port'] ) : '';
+
+	// Add the scheme
+	$uri = 'https://' . $uri;
+
 	$response = wp_remote_get( $uri, array(
 		/**
 		 * Do a HEAD request for efficiency.
 		 */
-		'method'      => 'HEAD',
+		'method' => 'HEAD',
 
 		/**
 		 * HEAD requests will not redirect by default. It is important that redirection works in case the
@@ -251,8 +264,7 @@ if ( ! function_exists( 'mcd_uri_has_secure_version' ) ) :
  * @return bool              True if URI is connectable; false if it is not.
  */
 function mcd_uri_has_secure_version( $uri ) {
-	$https_uri = set_url_scheme( $uri, 'https' );
-	return mcd_is_valid_uri( $https_uri );
+	return mcd_is_valid_uri( $uri );
 }
 endif;
 


### PR DESCRIPTION
In the beacon handler, the blocked URI is re-requested over HTTPS server-side in an attempt to see if it resolves (see `mcd_uri_has_secure_version()`). This then sets a flag on the violation report stating whether a secure version of the URI is available.

For scripts, styles, images, etc, this is probably fine, but I wonder whether it could be a concern to re-request other URIs such as iframe URLs (which are more likely to contain sensitive parameters) or GET XHR requests (which might cause problems if they're repeated).

Some options:
- Only re-request secure URIs for scripts, styles, fonts, images, objects. Don't re-request secure URIs for iframes or XHRs, and mark them as unknown. Not sure about form actions.
- Strip paths and/or query vars from URIs before re-requesting them, so only the path or only the domain name is requested. Might be less accurate if the HTTPS server for a given domain is different to its HTTP server.
